### PR TITLE
Add `googlefile` macro

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,10 +1,13 @@
 = Redmine Google Docs Plugin
 
-This is a plugin for Redmine that allows you to embed Google Spreadsheets and Docs into redmine pages. This is useful for keeping Google Docs-based documentation up-to-date with the issue queue. 
+This is a plugin for Redmine that allows you to embed Google Spreadsheets and
+Docs into redmine pages. This is useful for keeping Google Docs-based
+documentation up-to-date with the issue queue.
 
 http://evolvingweb.ca/sites/default/files/styles/large/public/googledoc_macro_steps.png
 
-For more information, see our blog post on this module: http://evolvingweb.ca/story/introducing-redmine-google-docs-plugin
+For more information, see our blog post on this module:
+http://evolvingweb.ca/story/introducing-redmine-google-docs-plugin
 
 == Installation
 

--- a/init.rb
+++ b/init.rb
@@ -42,5 +42,10 @@ Redmine::Plugin.register :redmine_googlesss do
     macro :googledoc do |obj, args|
       GoogleAppsMacros::DocumentMacros.get_doc(obj, args).html_safe
     end
+
+    desc 'Embed file from Google Drive (read-only view)'
+    macro :googlefile do |_, args|
+      GoogleAppsMacros::DocumentMacros.embed_file(args).html_safe
+    end
   end
 end

--- a/init.rb
+++ b/init.rb
@@ -1,45 +1,44 @@
 require 'redmine'
-
-require File.dirname(__FILE__) + '/lib/google_apps_macros.rb'
+require File.join(File.dirname(__FILE__), 'lib', 'google_apps_macros.rb')
 
 Redmine::Plugin.register :redmine_googlesss do
-  name "Google Docs Plugin"
+  name 'Google Docs Plugin'
   author 'Tavish Armstrong'
   description 'Embed Google Docs in your redmine pages.'
   version '0.0.2'
 
   Redmine::WikiFormatting::Macros.register do
-    desc = "Redmine Google Spreadsheet Macro (gs)"
+    desc = 'Redmine Google Spreadsheet Macro (gs)'
     macro :gs do |obj, args|
-      out = GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
+      GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = "Redmine Google Spreadsheet Macro (googless)"
+    desc = 'Redmine Google Spreadsheet Macro (googless)'
     macro :googless do |obj, args|
-      out = GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
+      GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = "Redmine Google Spreadsheet Macro (googlespreadsheet)"
+    desc = 'Redmine Google Spreadsheet Macro (googlespreadsheet)'
     macro :googlespreadsheet do |obj, args|
-      out = GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
+      GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = "Redmine Google Spreadsheet Macro (googlespread)"
+    desc = 'Redmine Google Spreadsheet Macro (googlespread)'
     macro :googlespread do |obj, args|
-      out = GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
+      GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = "Redmine Google Spreadsheet Macro (gi)"
+    desc = 'Redmine Google Spreadsheet Macro (gi)'
     macro :gi do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.get_issue(obj, args).html_safe
     end
 
-    desc = "Redmine Google Spreadsheet Macro (googleissue)"
+    desc = 'Redmine Google Spreadsheet Macro (googleissue)'
     macro :googleissue do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.get_issue(obj, args).html_safe
     end
 
-    desc = "Redmine Google Document Macro (googledoc)"
+    desc = 'Redmine Google Document Macro (googledoc)'
     macro :googledoc do |obj, args|
       GoogleAppsMacros::DocumentMacros.get_doc(obj, args).html_safe
     end

--- a/init.rb
+++ b/init.rb
@@ -8,37 +8,37 @@ Redmine::Plugin.register :redmine_googlesss do
   version '0.0.2'
 
   Redmine::WikiFormatting::Macros.register do
-    desc = 'Redmine Google Spreadsheet Macro (gs)'
+    desc 'Redmine Google Spreadsheet Macro (gs)'
     macro :gs do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = 'Redmine Google Spreadsheet Macro (googless)'
+    desc 'Redmine Google Spreadsheet Macro (googless)'
     macro :googless do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = 'Redmine Google Spreadsheet Macro (googlespreadsheet)'
+    desc 'Redmine Google Spreadsheet Macro (googlespreadsheet)'
     macro :googlespreadsheet do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = 'Redmine Google Spreadsheet Macro (googlespread)'
+    desc 'Redmine Google Spreadsheet Macro (googlespread)'
     macro :googlespread do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.googless_macro(obj, args).html_safe
     end
 
-    desc = 'Redmine Google Spreadsheet Macro (gi)'
+    desc 'Redmine Google Spreadsheet Macro (gi)'
     macro :gi do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.get_issue(obj, args).html_safe
     end
 
-    desc = 'Redmine Google Spreadsheet Macro (googleissue)'
+    desc 'Redmine Google Spreadsheet Macro (googleissue)'
     macro :googleissue do |obj, args|
       GoogleAppsMacros::SpreadsheetMacros.get_issue(obj, args).html_safe
     end
 
-    desc = 'Redmine Google Document Macro (googledoc)'
+    desc 'Redmine Google Document Macro (googledoc)'
     macro :googledoc do |obj, args|
       GoogleAppsMacros::DocumentMacros.get_doc(obj, args).html_safe
     end

--- a/lib/google_apps_macros.rb
+++ b/lib/google_apps_macros.rb
@@ -49,8 +49,8 @@ class SpreadsheetMacros
 
     # get a random string to add to the element IDs so multiple spreadsheets don't conflict.
     dom_id = Digest::MD5.hexdigest(rand().to_s)
-    
-    out = <<"EOF"
+
+    <<"EOF"
 <div>
   <style type="text/css">
   /* this is used to override the th and td className */
@@ -62,8 +62,8 @@ class SpreadsheetMacros
       margin-right: 50px;
     }
   </style>
-  <script type="text/javascript" src="https://www.google.com/jsapi"></script> 
-  <script type="text/javascript"> 
+  <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+  <script type="text/javascript">
   (function () {
     var prot, options, tableId, fakeSql, key, baseUrl;
 
@@ -76,7 +76,7 @@ class SpreadsheetMacros
         headerCell: 'small-font'
       }
     };
-  	// We want this to be unique for each embedded sheet. Otherwise only one sheet can display per page.
+    // We want this to be unique for each embedded sheet. Otherwise only one sheet can display per page.
     tableId = 'table-' + "#{dom_id}";
     fakeSql = '#{query}';
     key = '#{key}';
@@ -85,7 +85,7 @@ class SpreadsheetMacros
     baseUrl = 'docs.google.com/spreadsheet';
 
     google.load('visualization', '1.s');
-    
+
     function drawVisualization() {
       google.visualization.drawChart({
         "containerId": tableId,
@@ -129,7 +129,6 @@ EOF
   def self.get_issue(obj, args)
     # usage: {{googleissue(adfSDFiuhDSF98SDFhiushdafbhIDFXF0dsf)}}
     # gives the row of the google spreadsheet containing the issue number in the second column
-    goodargs = []
     key = clean_key(args[0])
     if args.length > 1
       sheet = clean_key(args[1])
@@ -154,7 +153,7 @@ EOF
 
       clean_query = clean_key(query)
 
-      out = render_spreadsheet(key, clean_query, sheet, "true")
+      render_spreadsheet(key, clean_query, sheet, "true")
     else
       raise "You need to be on an issue page to use the <strong>googleissue</strong> macro."
     end
@@ -196,7 +195,7 @@ class DocumentMacros
       else
         url += "pub?id=#{doc_key}"
       end
-      out = "<iframe src='#{url}' width='800' height='400'></iframe>"
+      %(<iframe src="#{url}" width="800" height="400"></iframe>)
     else
       raise "The Google document key must be alphanumeric."
     end

--- a/lib/google_apps_macros.rb
+++ b/lib/google_apps_macros.rb
@@ -165,6 +165,10 @@ EOF
 end
 
 class DocumentMacros
+  def self.base_url
+    "https://drive.google.com"
+  end
+
   def self.get_doc(obj, args)
     doc_key = args[0]
     action = false
@@ -185,11 +189,7 @@ class DocumentMacros
       action = "view" if args[2].strip == "view"
     end
     if /^[\w-]+$/.match(doc_key)
-      if domain
-        url = "https://docs.google.com/a/#{domain}/document/"
-      else
-        url = "https://docs.google.com/document/"
-      end
+      url = "#{base_url}#{domain_part(domain)}/document/"
       if action
         url += "d/#{doc_key}/#{action}"
       else
@@ -200,5 +200,23 @@ class DocumentMacros
       raise "The Google document key must be alphanumeric."
     end
   end
+
+  def self.embed_file(args)
+    key = args[0]
+    domain = args.length == 2 ? args[1].strip : nil
+    height = args.length == 3 ? args[2].to_i : 600
+    url = "#{base_url}#{domain_part(domain)}/file/d/#{key}/view"
+    style = "width: 100%; height: #{height}px;"
+    %(<iframe src="#{url}" style="#{style}"></iframe>)
+  end
+
+  def self.domain_part(domain)
+    if domain.nil? || domain == "nil"
+      "/"
+    else
+      "/a/#{domain}"
+    end
+  end
 end
+
 end


### PR DESCRIPTION
To render read-only file previews. For example it allows one to embed
a PDF document into a Wiki.

Usage:

```
{{googlefile(key, domain, height)}}
```

Example:

```
{{googlefile(1tue9Oj0iMl5Gz752F5rud6LZzo3YjHmqPD7d82cdQyw, example.com, 800) }}
```

P.S. Along with minor code style fixes.
